### PR TITLE
会話ログページの実装

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -31,7 +31,7 @@ export default function LogPage() {
     .filter((chapter): chapter is StoryChapter => !!chapter && chapter.type === 'story');
 
   return (
-    <div className="min-h-screen bg-gray-200 text-white p-4 sm:p-6 md:p-8 font-sans">
+    <div className="min-h-screen bg-white p-4 sm:p-6 md:p-8 font-sans">
       <div className="max-w-4xl mx-auto">
         <header className="mb-8 flex justify-between items-center">
           <div>
@@ -48,22 +48,22 @@ export default function LogPage() {
           </div>
           <button
             onClick={() => router.back()}
-            className="px-6 py-2 bg-cyan-600 hover:bg-cyan-700 rounded-lg shadow-md transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-400"
+            className="fixed left-4/6 px-6 py-2 hover:bg-cyan-700 rounded-lg shadow-md transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-400 border-black border"
           >
             ゲームに戻る
           </button>
         </header>
 
-        <main className="space-y-6 bg-gray-800/50 p-6 rounded-lg shadow-inner">
+        <main className="space-y-6 bg-white p-6 rounded-lg shadow-inner border-black border">
           {storyLogs.length > 0 ? (
             storyLogs.map((chapter) => (
               <div key={chapter.id} className="border-b border-gray-700 pb-4 last:border-b-0">
-                <h2 className="text-xl font-semibold text-yellow-300 mb-2">
+                <h2 className="text-xl font-semibold text-black mb-2">
                   {/* gameDataにチャプタータイトルがあれば表示、なければIDを表示 */}
                   {/* StoryChapterにtitleはないため、IDを fallback として表示 */}
                   {`チャプター: ${chapter.id}`}
                 </h2>
-                <div className="text-gray-100 whitespace-pre-wrap leading-relaxed">
+                <div className="text-black whitespace-pre-wrap leading-relaxed">
                   {/* contentは文字列配列なので、各行をdivで囲んで表示 */}
                   {chapter.content.map((line, index) => (
                     <p key={index}>{line}</p>

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useGame } from '@/app/provider/GameProvider';
+import { gameData, StoryChapter } from '@/lib/gameData';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import Timer from "@/components/game/Timer";
+
+export default function LogPage() {
+  const router = useRouter();
+  // `useGame`からタイマー関連のstateと現在のチャプターIDを取得
+  const { viewedStoryChapters, currentChapterId, remainingTime, pauseTimer, resumeTimer } = useGame();
+
+  // 現在のチャプターがパズルかどうかを判定
+  const isPuzzleActive = gameData[currentChapterId]?.type === 'puzzle';
+
+  // このページが表示されている間タイマーを再開し、離れるときに一時停止する
+  useEffect(() => {
+    if (isPuzzleActive) {
+      resumeTimer();
+      return () => {
+        pauseTimer();
+      };
+    }
+  }, [isPuzzleActive, pauseTimer, resumeTimer]);
+
+  // 閲覧済みのチャプターIDの中から、'story'タイプのチャプターのみをフィルタリング
+  const storyLogs = viewedStoryChapters
+    .map(id => gameData[id]) // gamedataから直接IDでチャプターを取得
+    // 型ガードを使用してstoryタイプのみに絞り込み、TypeScriptに型を推論させる
+    .filter((chapter): chapter is StoryChapter => !!chapter && chapter.type === 'story');
+
+  return (
+    <div className="min-h-screen bg-gray-200 text-white p-4 sm:p-6 md:p-8 font-sans">
+      <div className="max-w-4xl mx-auto">
+        <header className="mb-8 flex justify-between items-center">
+          <div>
+            <h1 className="text-3xl font-bold text-black">会話ログ</h1>
+            {/* パズルがアクティブな場合のみ残り時間を表示 */}
+            {isPuzzleActive && remainingTime !== undefined && (
+            //   <div className="text-xl text-red-400 mt-2 animate-pulse">
+            //     残り時間: {formatTime(remainingTime)}
+            //   </div>
+            <div className="absolute h-1/15 top-1/30 w-1/10 right-1/30 border rounded-xl border-black flex justify-center items-center text-center text-black">
+                <Timer />
+            </div>
+            )}
+          </div>
+          <button
+            onClick={() => router.back()}
+            className="px-6 py-2 bg-cyan-600 hover:bg-cyan-700 rounded-lg shadow-md transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-400"
+          >
+            ゲームに戻る
+          </button>
+        </header>
+
+        <main className="space-y-6 bg-gray-800/50 p-6 rounded-lg shadow-inner">
+          {storyLogs.length > 0 ? (
+            storyLogs.map((chapter) => (
+              <div key={chapter.id} className="border-b border-gray-700 pb-4 last:border-b-0">
+                <h2 className="text-xl font-semibold text-yellow-300 mb-2">
+                  {/* gameDataにチャプタータイトルがあれば表示、なければIDを表示 */}
+                  {/* StoryChapterにtitleはないため、IDを fallback として表示 */}
+                  {`チャプター: ${chapter.id}`}
+                </h2>
+                <div className="text-gray-100 whitespace-pre-wrap leading-relaxed">
+                  {/* contentは文字列配列なので、各行をdivで囲んで表示 */}
+                  {chapter.content.map((line, index) => (
+                    <p key={index}>{line}</p>
+                  ))}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-center py-10">
+              <p className="text-gray-400 text-lg">まだ会話ログはありません。</p>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/StoryChapter.tsx
+++ b/src/components/StoryChapter.tsx
@@ -37,12 +37,6 @@ export default function StoryChapter({ chapterId, lines, onComplete }: StoryChap
   };
   return (
     <div>
-      <button
-        onClick={() => router.push("/log")}
-        className="absolute h-1/15 w-1/5  border border-black flex justify-center items-center text-center"
-      >
-        会話を見る
-      </button>
       <div
         className='absolute bottom-16 h-1/4 w-4/5 left-1/10 border rounded-3xl border-black flex justify-center items-center text-center text-xl'
         onClick={handleNextLine}

--- a/src/components/StoryChapter.tsx
+++ b/src/components/StoryChapter.tsx
@@ -2,6 +2,7 @@
 
 import { useGame } from '@/app/provider/GameProvider';
 import { useEffect, useState } from 'react';
+import { useRouter } from "next/navigation";
 
 interface StoryChapterProps {
   chapterId: string;
@@ -10,6 +11,7 @@ interface StoryChapterProps {
 }
 
 export default function StoryChapter({ chapterId, lines, onComplete }: StoryChapterProps) {
+  const router = useRouter();
   const [currentLineIndex, setCurrentLineIndex] = useState(0);
   const { setGameState , pauseTimer} = useGame();
   useEffect(() => {
@@ -34,13 +36,21 @@ export default function StoryChapter({ chapterId, lines, onComplete }: StoryChap
     }
   };
   return (
-    <div
-      className='absolute bottom-16 h-1/4 w-4/5 left-1/10 border rounded-3xl border-black flex justify-center items-center text-center text-xl'
-      onClick={handleNextLine}
-    >
-      <div>
-        <p>{lines[currentLineIndex]}</p>
-        <div>▼</div>
+    <div>
+      <button
+        onClick={() => router.push("/log")}
+        className="absolute h-1/15 w-1/5  border border-black flex justify-center items-center text-center"
+      >
+        会話を見る
+      </button>
+      <div
+        className='absolute bottom-16 h-1/4 w-4/5 left-1/10 border rounded-3xl border-black flex justify-center items-center text-center text-xl'
+        onClick={handleNextLine}
+      >
+        <div>
+          <p>{lines[currentLineIndex]}</p>
+          <div>▼</div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/game/PuzzleDisplay.tsx
+++ b/src/components/game/PuzzleDisplay.tsx
@@ -63,7 +63,13 @@ export default function PuzzleDisplay({ puzzle, onSolved }: PuzzleDisplayProps) 
     <div className="puzzle-container">
       <div className="absolute h-1/15 top-1/30 w-1/10 right-1/30 border rounded-xl border-black flex justify-center items-center text-center">
         <Timer />
-      </div>      
+      </div>
+      <button
+        onClick={() => router.push("/log")}
+        className="absolute h-1/15 w-1/5  border border-black flex justify-center items-center text-center"
+      >
+        会話を見る
+      </button>
       <h2 className="puzzle-question absolute top-32 h-1/3 w-28/30 left-1/30 border rounded-3xl border-black flex justify-center items-center text-center text-xl">
         {puzzle.question}
       </h2>
@@ -72,6 +78,7 @@ export default function PuzzleDisplay({ puzzle, onSolved }: PuzzleDisplayProps) 
         value={playerInput}
         onChange={(e) => setPlayerInput(e.target.value)}
         placeholder="答えを入力"
+        className="absolute left-1/2"
       />
 
       <button

--- a/src/lib/gameData.ts
+++ b/src/lib/gameData.ts
@@ -1,4 +1,5 @@
 export interface StoryChapter {
+    id: string;
     type: "story";
     content: string[];
     nextChapterId: string;
@@ -30,6 +31,7 @@ export type GameChapter = StoryChapter | PuzzleChapter | ActionChapter | EndingC
 
 export const gameData:Record<string, GameChapter> ={
     'start': {
+    id: 'chapter1',
     type: 'story',
     content: [
       "AI: ようこそ、挑戦者よ。",
@@ -70,6 +72,7 @@ export const gameData:Record<string, GameChapter> ={
    * 中盤: ドア操作と謎解き4
    */
   'door-open-story': {
+    id: 'chapter2-1',
     type: 'story',
     content: ["AI: よくやった。目の前のドアを操作する権限を与える。", "AI: パネルを操作して、次のエリアへ進め。"],
     nextChapterId: 'action-door-open',
@@ -81,6 +84,7 @@ export const gameData:Record<string, GameChapter> ={
     nextChapterId: 'puzzle-4-story',
   },
   'puzzle-4-story': {
+    id: 'chapter2-2',
     type: 'story',
     content: ["AI: このエリアは危険だ。センサーに触れないよう、慎重に進め。"],
     nextChapterId: 'puzzle-4',
@@ -96,6 +100,7 @@ export const gameData:Record<string, GameChapter> ={
   },
 
   'projector-start-story': {
+    id: 'chapter3',
     type: 'story',
     content: ["AI: 残す謎はあと一つ...。部屋の様子が変わる。よく観察しろ。"],
     nextChapterId: 'action-projector-lights-on',
@@ -126,6 +131,7 @@ export const gameData:Record<string, GameChapter> ={
     nextChapterId: 'success-story',
   },
   'success-story': {
+    id: 'clear',
     type: 'story',
     content: ["AI: 見事だ、挑戦者よ。君の勝利だ。", "AI: 出口は目の前だ。"],
     nextChapterId: 'success',
@@ -135,6 +141,7 @@ export const gameData:Record<string, GameChapter> ={
    * ゲームオーバー / クリア画面
    */
   'final-story': {
+    id: 'clear',
     type: 'story',
     content: ["AI: よくやった。これで全ての謎を解き明かした。"],
     nextChapterId: 'success', // ★ 次のチャプターを'success'に設定


### PR DESCRIPTION
<!--
Pull Requestありがとうございます！
Pull Requestを作成するにあたり、以下の内容を記述してください。

Tip: ファイルをドラッグ＆ドロップすると、画像やファイルを添付できます。
-->

## 概要

<!--
このPull Requestで何を行なったのか、
どう変わるのかを明確かつ簡潔に記述してください。
-->

- 会話ログページ実装
- ストーリーチャプター画面、謎解き基本画面の左上に会話ログページへのボタンを配置
- 謎解き基本画面から会話ログページへの遷移時のみ、タイマーを表示

## 関連する Issue

- 「会話ログページ」の実装 #13
<!--
関連するIssueがあれば番号を記述してください。
-->

## 補足事項

<!--
相談したい内容や残っている課題など、
伝えたい内容があれば記述してください。
また、関連するリンクや参考資料などがあれば教えてください。
-->

会話進行時、パズル画面時問わず画面左上に実装した「会話を見る」ボタンを押すと/logに飛びそこまでに確認した会話のログを見ることができる。 パズル画面から呼び出した（タイマーが進行している）ときはログ画面内にもタイマーを表示し、カウントも進行する。 会話ログ表示の都合上必要だったため、GameData.ts内のstoryタイプにidを追加。